### PR TITLE
Add multi period ACOPF model

### DIFF
--- a/src/opf.jl
+++ b/src/opf.jl
@@ -548,3 +548,51 @@ function compute_opf_in_parallel(
 
     return acopf_solutions
 end
+
+function compute_multiperiod_opf(
+    data,
+    on_status;
+    optimizer = nothing,
+    ipopt_linear_solver = nothing,
+    return_model = true,
+)
+    if optimizer === nothing
+        if ipopt_linear_solver === nothing
+            # linear solver was not specified. We defer selection
+            # of the default to Ipopt
+            optimizer = JuMP.optimizer_with_attributes(
+                Ipopt.Optimizer,
+                "honor_original_bounds" => "yes",
+                "tol" => 1e-6,
+                "acceptable_tol" => 1e-4,
+            )
+        else
+            # Use the linear solver specified
+            optimizer = JuMP.optimizer_with_attributes(
+                Ipopt.Optimizer,
+                "honor_original_bounds" => "yes",
+                "acceptable_tol" => 1e-4,
+                "linear_solver" => ipopt_linear_solver,
+            )
+        end
+    end
+    args = Dict("on_status" => on_status)
+    model = get_multiperiod_acopf_model(data, args=args)
+
+    JuMP.set_optimizer(model, optimizer)
+    MOI.set(model, Ipopt.CallbackFunction(), ipopt_acceptable_callback)
+    JuMP.optimize!(
+        model,
+        _differentiation_backend = MathOptSymbolicAD.DefaultBackend()
+    )
+    output_data = extract_data_from_multiperiod_model(
+        model,
+        data,
+        on_status,
+    )
+    if return_model
+        return model, output_data
+    else
+        return nothing, output_data
+    end
+end

--- a/src/opf.jl
+++ b/src/opf.jl
@@ -576,14 +576,18 @@ function compute_multiperiod_opf(
             )
         end
     end
-    args = Dict("on_status" => on_status)
+    args = Dict(
+        "on_status" => on_status,
+        # TODO: Allow an option to relax, round, and re-solve shunt steps
+        "fix_shunt_steps" => true,
+    )
     model = get_multiperiod_acopf_model(data, args=args)
 
     JuMP.set_optimizer(model, optimizer)
     MOI.set(model, Ipopt.CallbackFunction(), ipopt_acceptable_callback)
     JuMP.optimize!(
         model,
-        _differentiation_backend = MathOptSymbolicAD.DefaultBackend()
+        _differentiation_backend = MathOptSymbolicAD.DefaultBackend(),
     )
     output_data = extract_data_from_multiperiod_model(
         model,

--- a/src/opf_model.jl
+++ b/src/opf_model.jl
@@ -881,7 +881,11 @@ function get_ac_opf_model(data::NamedTuple, period::Int; args=nothing)
 end
 
 
-function get_multiperiod_acopf_model(data::NamedTuple; args=nothing)
+function get_multiperiod_acopf_model(
+    data::NamedTuple;
+    args=nothing,
+    optimizer=nothing,
+)
     if args === nothing
         args = Dict{String, Any}()
     end
@@ -959,7 +963,11 @@ function get_multiperiod_acopf_model(data::NamedTuple; args=nothing)
     bus_shunt_ids = topo_data.bus_shunt_ids
     bus_branch_keys = topo_data.bus_branch_keys
 
-    model = JuMP.Model()
+    if optimizer === nothing
+        model = JuMP.Model()
+    else
+        model = JuMP.Model(optimizer)
+    end
 
     # In a loop, construct variables and constraints for ACOPF at every point
     # in time.

--- a/src/opf_model.jl
+++ b/src/opf_model.jl
@@ -201,6 +201,11 @@ function add_real_reactive_linear_constraints!(
     beta = Dict(uid => sdd_lookup[uid]["beta"] for uid in pq_linear_sdds)
 
     if periods === nothing
+        # Really, we would like something like a "null index", which is an identity
+        # with respect to the cartesian (set) product.
+        # How should this behave when iterating over only this identity set?
+        # We need some way of accessing an unindexed component with a null index.
+        # Pyomo's convention is to use the singleton {None}.
         periods = [nothing]
     end
     if p === nothing
@@ -986,7 +991,7 @@ function get_multiperiod_acopf_model(data::NamedTuple; args=nothing)
     max_balance_violation = get(args, "max_balance_violation", nothing)
     allow_switching = get(args, "allow_switching", true)
     fix_shunt_steps = get(args, "fix_shunt_steps", false)
-    relax_thermal_limits = get(args, "relax_thermal_limits", false)
+    #relax_thermal_limits = get(args, "relax_thermal_limits", false)
     sdd_to_lb = get(args, "sdd_to_lb", Vector())
     sdd_to_ub = get(args, "sdd_to_ub", Vector())
 
@@ -1001,20 +1006,33 @@ function get_multiperiod_acopf_model(data::NamedTuple; args=nothing)
 
     # If not provided, create default dicts that do not filter any SDDs
     #
+    # TODO: on_status is basically required. Maybe it should be a positional
+    # arg?
+    #
     # on_status is used to determine which devices should have their power levels
     # fixed (i.e. are in su/sd curves). We use a dict that is ducktype-compatible
     # with on_status variables from the UC problem
     if "on_status" in keys(args)
+        # We store the original on-status, as this data structure is required for
+        # a few data processing functions
+        orig_on_status = args["on_status"]
         on_status = Dict((uid, i) => args["on_status"][uid][i] for uid in sdd_ids for i in periods)
     else
+        orig_on_status = Dict(uid => [1 for i in periods] for uid in sdd_ids)
         on_status = Dict((uid, i) => 1 for uid in sdd_ids for i in periods)
     end
+
     # This is used to determine if devices are in an SU/SD curve when on_status=0.
-    # If this
+    # We should not need this for the MP formulation, as we have the entire sequence
+    # of on-statuses
     p_dict = get(args, "real_power", Dict())
 
     # This is an indicator that a device is online or in an SU/SD curve.
     # Eventually, I will want this to be a JuMP expression
+    # NOTE: This should not be necessary, as I can always (a) infer su/sd
+    # from on_status or (b) accept them as inputs (e.g. if they are variables).
+    # Will it ever be more convenient to use on-su-sd-status explicitly
+    # in this model? If so, I can construct it from on_status/u_su/u_sd.
     on_su_sd_status = Dict{Tuple{String, Int}, Any}()
     for uid in sdd_ids
         for i in periods
@@ -1055,33 +1073,478 @@ function get_multiperiod_acopf_model(data::NamedTuple; args=nothing)
     bus_branch_keys = topo_data.bus_branch_keys
 
     model = JuMP.Model()
+
     # In a loop, construct variables and constraints for ACOPF at every point
     # in time.
     @variable(model, bus_lookup[uid]["vm_lb"] <= vm[uid in bus_ids, t in periods] <= bus_lookup[uid]["vm_ub"], start=1.0)
     @variable(model, va[uid in bus_ids, t in periods])
+
+    # Since we will have on-status implication constraints, the domain of p/q-sdd
+    # variables always need to include zero.
     @variable(model,
-        sdd_ts_lookup[uid]["p_lb"][t] <= p_sdd[uid in sdd_ids, t in periods] <= sdd_ts_lookup[uid]["p_ub"][t]
+        min(sdd_ts_lookup[uid]["p_lb"][t], 0.0)
+        <= p_sdd[uid in sdd_ids, t in periods]
+        <= max(sdd_ts_lookup[uid]["p_ub"][t], 0.0)
     )
     @variable(model,
-        sdd_ts_lookup[uid]["q_lb"][t] <= q_sdd[uid in sdd_ids, t in periods] <= sdd_ts_lookup[uid]["q_ub"][t]
+        min(sdd_ts_lookup[uid]["q_lb"][t], 0.0)
+        <= q_sdd[uid in sdd_ids, t in periods]
+        <= max(sdd_ts_lookup[uid]["q_ub"][t], 0.0)
     )
+
     @variable(model, p_branch[uid in branch_keys, t in periods])
     @variable(model, q_branch[uid in branch_keys, t in periods])
-    if relax_thermal_limits
-        @variable(model, ac_thermal_slack[uid in ac_line_ids, t in periods] >= 0.0)
-        @variable(model, twt_thermal_slack[uid in twt_ids, t in periods] >= 0.0)
-    end
+    # TODO: Support thermal limit relaxation if necessary
+    #if relax_thermal_limits
+    #    @variable(model, ac_thermal_slack[uid in ac_line_ids, t in periods] >= 0.0)
+    #    @variable(model, twt_thermal_slack[uid in twt_ids, t in periods] >= 0.0)
+    #end
 
     # These constraints are now indexed by periods.
     # These constraints, and probably others, will need u_su+u_sd+u_on
-    pq_ub, pq_lb, pq_eq = add_real_reactive_linear_constraints!(
-        model, sdd_ids, data; p=p_sdd, q=q_sdd, periods=periods, on_su_sd_status=on_su_sd_status
+    #
+    # This is necessary for the MP problem, but will not be necessary when
+    # building on top of the UC problem. Ideally, this could reuse the
+    # implementation from the UC model.
+    # Re-using the UC implementation requires the following additional data:
+    # - T_su/sd power curve intervals
+    # - u_su/sd status indicators
+    # Additionally, we would need to:
+    # - explicitly pass in p/q-sdd (to deal with different naming conventions)
+    # - Pass in a mocked-up u_on dict (with constants or variables)
+    # - use include_reserves=false
+    # The UC model implementation has the advantages of:
+    # - an option to include reserves
+    # - handle u_su/sd variables. Could this be a downside in some context?
+    #   - This implies a structural definition of on-su-sd status, which is good
+    # But what if I don't have u_su/u_sd? Is this a viable situation?
+    # - I can always infer on-su-sd from p-on
+    # - u_su/sd should be inferrable from on-status
+    #pq_ub, pq_lb, pq_eq = add_real_reactive_linear_constraints!(
+    #    model, sdd_ids, data; p=p_sdd, q=q_sdd, periods=periods, on_su_sd_status=on_su_sd_status
+    #)
+    # Alternative:
+    #_, p_su_ru, _, p_sd_rd = get_contiguous_power_curves(data)
+    T_su_pc, T_sd_pc = get_inverse_power_curve_intervals(data)
+    # With fixed on status, we should be able to compute u_su/sd
+    # TODO: don't attempt to compute these if variables are provided (rather than
+    # constants)
+    u_su, u_sd = get_su_sd_from_on_status(data, orig_on_status)
+    # Create dicts that are ducktype-compatible with JuMP variables
+    u_su = Dict((uid, i) => u_su[uid][i] for uid in sdd_ids for i in periods)
+    u_sd = Dict((uid, i) => u_sd[uid][i] for uid in sdd_ids for i in periods)
+
+    add_real_reactive_linking_constraints!(
+        model, data, T_su_pc, T_sd_pc;
+        pq=(p_sdd, q_sdd), u_on=on_status, u_susd=(u_su, u_sd), include_reserves = false
     )
+
+    in_supc, p_su, in_sdpc, p_sd = get_supc_sdpc_lookups(data, orig_on_status)
+
     # For now, these constraints serve the purpose of fixing devices that are not online.
     # (Otherwise the bounds imposed are redundant.)
     # In the future, they will actually incorporate discrete variables.
-    add_semicontinuous_bound_constraints!(
-        model, data, periods=periods, on_status=on_status, on_su_sd_status=on_su_sd_status
+    #add_semicontinuous_bound_constraints!(
+    #    model, data, periods=periods, on_status=on_status, on_su_sd_status=on_su_sd_status
+    #)
+    # Alternatively, we can reuse the implementation from the scheduling model:
+    #
+    # Note that, in this OPF formulation, p_sdd is the aggregated p_on+p_su+p_sd
+    # variable. In the context where on-status is fixed, p_sdd will need to be
+    # fixed when we are in a power curve. The alternative is to add explicit
+    # p-su/sd variables and power curve constraints.
+    # However, there is nothing wrong with the following constraints. The p-su/sd
+    # implication constraints will be redundant, but that is okay.
+
+    # Fix power for devices in power curves
+    # NOTE: This will need to change if on-status is not fixed
+    mock_p_on = Dict()
+    for uid in sdd_ids
+        for i in periods
+            # Note that p_sdd is implicitly fixed by the above implications if
+            # on_status == 0.
+            if Bool(in_supc[uid][i])
+                JuMP.fix(p_sdd[uid, i], p_su[uid][i], force = true)
+            end
+            if Bool(in_sdpc[uid][i])
+                JuMP.fix(p_sdd[uid, i], p_sd[uid][i], force = true)
+            end
+            if Bool(on_status[uid, i])
+                mock_p_on[uid, i] = p_sdd[uid, i]
+            else
+                mock_p_on[uid, i] = 0.0
+            end
+        end
+    end
+
+    mock_p_su = Dict((uid, i) => p_su[uid][i] for uid in sdd_ids for i in periods)
+    mock_p_sd = Dict((uid, i) => p_sd[uid][i] for uid in sdd_ids for i in periods)
+    # Note that, with on_status fixed, this will give many trivial constraints
+    # (p_su/p_sd are constants).
+    add_on_su_sd_implication_constraints!(model, data; include_reserves=false,
+        p_on=mock_p_on, u_on=on_status, p_su=mock_p_su, p_sd=mock_p_sd,
+    )
+
+    # TODO: Integer domain and explicitly relax?
+    @variable(
+        model,
+        shunt_lookup[uid]["step_lb"]
+        <= shunt_step[uid in shunt_ids, i in periods]
+        <= shunt_lookup[uid]["step_ub"]
+    )
+    if fix_shunt_steps
+        for uid in shunt_ids
+            init_step = shunt_lookup[uid]["initial_status"]["step"]
+            JuMP.fix.(shunt_step[uid, :], init_step, force = true)
+        end
+    end
+
+    # Add slack variables for power balance relaxation (which we usually use)
+    if relax_p_balance
+        if max_balance_violation !== nothing
+            p_balance_slack_pos = @variable(
+                model,
+                0 <= p_balance_slack_pos[bus_ids, periods] <= max_balance_violation,
+            )
+            p_balance_slack_neg = @variable(
+                model,
+                0 <= p_balance_slack_neg[bus_ids, periods] <= max_balance_violation,
+            )
+        else
+            p_balance_slack_pos = @variable(model, 0 <= p_balance_slack_pos[bus_ids, periods])
+            p_balance_slack_neg = @variable(model, 0 <= p_balance_slack_neg[bus_ids, periods])
+        end
+        p_balance_penalty = violation_cost["p_bus_vio_cost"]
+    end
+    if relax_q_balance
+        if max_balance_violation !== nothing
+            q_balance_slack_pos = @variable(
+                model,
+                0 <= q_balance_slack_pos[bus_ids, periods] <= max_balance_violation,
+            )
+            q_balance_slack_neg = @variable(
+                model,
+                0 <= q_balance_slack_neg[bus_ids, periods] <= max_balance_violation,
+            )
+        else
+            q_balance_slack_pos = @variable(model, 0 <= q_balance_slack_pos[bus_ids, periods])
+            q_balance_slack_neg = @variable(model, 0 <= q_balance_slack_neg[bus_ids, periods])
+        end
+        q_balance_penalty = violation_cost["q_bus_vio_cost"]
+    end
+
+    for (uid, bus) in bus_lookup
+        @constraint(model, [i in periods], va[uid, i] == 0.0)
+        break
+    end
+
+    # Implement piecewise-linear cost functions
+    device_cost = Dict()
+    for uid in sdd_ids
+        for t in periods
+            cost_blocks = sdd_ts_lookup[uid]["cost"][t]
+            cost_block_p = @variable(model,
+                [i in 1:length(cost_blocks)],
+                lower_bound = 0.0,
+                upper_bound = cost_blocks[i][2]
+            )
+            device_cost[uid, t] = @expression(model,
+                sum(
+                    cb[1]*cost_block_p[i] for (i, cb) in enumerate(cost_blocks),
+                    init = 0
+                )
+            )
+            JuMP.@constraint(model, p_sdd[uid, t] == sum(cost_block_p, init = 0))
+        end
+    end
+
+    # Create penalty terms for power balance violations
+    if relax_p_balance
+        p_balance_penalty_term = @expression(model,
+            [i in periods],
+            p_balance_penalty*sum(
+                p_balance_slack_pos[uid, i] + p_balance_slack_neg[uid, i]
+                for uid in bus_ids,
+                init = 0
+            )
+        )
+    else
+        p_balance_penalty_term = 0.0
+    end
+    if relax_q_balance
+        q_balance_penalty_term = @expression(model,
+            [i in periods],
+            q_balance_penalty*sum(
+                q_balance_slack_pos[uid, i] + q_balance_slack_neg[uid, i]
+                for uid in bus_ids,
+                init = 0
+            )
+        )
+    else
+        q_balance_penalty_term = 0.0
+    end
+    # TODO: Thermal limit penalty expressions?
+    # (Only if I allow relaxing these constraints.)
+
+    @objective(model, Max, sum(
+        dt[t] * (
+            sum(device_cost[uid, t] for uid in sdd_ids_consumer, init = 0)
+            - sum(device_cost[uid, t] for uid in sdd_ids_producer, init = 0)
+            - p_balance_penalty_term[t]
+            - q_balance_penalty_term[t]
+        ) for t in periods
+    ))
+
+    # TODO: Implement constraints
+    # - Standard ACOPF constraints, now indexed by time
+    # - Ramping constraints
+    # - Potentiall max-energy-over-interval constraints?
+    if relax_p_balance
+        @NLconstraint(model, 
+            p_balance[uid in bus_ids, i in periods],
+            sum(p_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) -
+            sum(
+                shunt_lookup[shunt_id]["gs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #gs*vm[uid]^2
+            # Add positive and negative slack variables
+            + (p_balance_slack_pos[uid, i] - p_balance_slack_neg[uid, i])
+        )
+    else
+        @NLconstraint(model, 
+            p_balance[uid in bus_ids, i in periods],
+            sum(p_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) -
+            sum(
+                shunt_lookup[shunt_id]["gs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #gs*vm[uid]^2
+        )
+    end
+    if relax_q_balance
+        @NLconstraint(model, 
+            q_balance[uid in bus_ids, i in periods],
+            sum(q_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) +
+            sum(
+                shunt_lookup[shunt_id]["bs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #bs*vm[uid]^2
+            # Add positive and negative slack variables
+            + (q_balance_slack_pos[uid, i] - q_balance_slack_neg[uid, i])
+        )
+    else
+        @NLconstraint(model, 
+            q_balance[uid in bus_ids, i in periods],
+            sum(q_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) +
+            sum(
+                shunt_lookup[shunt_id]["bs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #bs*vm[uid]^2
+        )
+    end
+
+    for (uid,ac_line) in ac_line_lookup, i in periods
+        branch = ac_line
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        #if relax_thermal_limits
+        #    s_thermal = ac_thermal_slack[uid]
+        #else
+        #    s_thermal = 0.0
+        #end
+
+        vm_fr = vm[branch["fr_bus"], i]
+        vm_to = vm[branch["to_bus"], i]
+        va_fr = va[branch["fr_bus"], i]
+        va_to = va[branch["to_bus"], i]
+
+        r = branch["r"]
+        x = branch["x"]
+        y = 1 / (r + im*x)
+        g = real(y)
+        b = imag(y)
+
+        tm = 1.0
+        ta = 0.0
+        tr = tm * cos(ta)
+        ti = tm * sin(ta)
+        ttm = tm^2
+
+        g_fr = 0.0
+        b_fr = branch["b"]/2.0
+        g_to = 0.0
+        b_to = branch["b"]/2.0
+
+        if branch["additional_shunt"] == 1
+            g_fr += branch["g_fr"]
+            b_fr += branch["b_fr"]
+            g_to += branch["g_to"]
+            b_to += branch["b_to"]
+        end
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(p_to, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_to, -10.0*branch["mva_ub_nom"])
+
+        JuMP.set_upper_bound(p_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(p_to,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_to,  10.0*branch["mva_ub_nom"])
+
+        # From side of the branch flow
+        JuMP.@NLconstraint(model, p_fr ==  (g+g_fr)/ttm*vm_fr^2 + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-b*tr-g*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+        JuMP.@NLconstraint(model, q_fr == -(b+b_fr)/ttm*vm_fr^2 - (-b*tr-g*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+
+        # To side of the branch flow
+        JuMP.@NLconstraint(model, p_to ==  (g+g_to)*vm_to^2 + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-b*tr+g*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+        JuMP.@NLconstraint(model, q_to == -(b+b_to)*vm_to^2 - (-b*tr+g*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+
+        # Voltage angle difference limit
+        JuMP.@constraint(model, vad_lb <= va_fr - va_to <= vad_ub)
+
+        # Apparent power limit, from side and to side
+        # TODO: What is the best way to formulate this as a soft constraint?
+        # Square root? Or (s_max + slack)^2?
+        # TODO: Potentially re-add option to relax
+        JuMP.@constraint(model, p_fr^2 + q_fr^2 <= (branch["mva_ub_nom"])^2)
+        JuMP.@constraint(model, p_to^2 + q_to^2 <= (branch["mva_ub_nom"])^2)
+    end
+
+    for (uid,twt) in twt_lookup, i in periods
+        branch = twt
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        #if relax_thermal_limits
+        #    s_thermal = twt_thermal_slack[uid]
+        #else
+        #    s_thermal = 0.0
+        #end
+
+        vm_fr = vm[branch["fr_bus"], i]
+        vm_to = vm[branch["to_bus"], i]
+        va_fr = va[branch["fr_bus"], i]
+        va_to = va[branch["to_bus"], i]
+
+        r = branch["r"]
+        x = branch["x"]
+        y = 1 / (r + im*x)
+        g = real(y)
+        b = imag(y)
+
+        initial_status = branch["initial_status"]
+
+        tm = initial_status["tm"]
+        ta = initial_status["ta"]
+        tr = tm * cos(ta)
+        ti = tm * sin(ta)
+        ttm = tm^2
+
+        g_fr = 0.0
+        b_fr = branch["b"]/2.0
+        g_to = 0.0
+        b_to = branch["b"]/2.0
+
+        if branch["additional_shunt"] == 1
+            g_fr += branch["g_fr"]
+            b_fr += branch["b_fr"]
+            g_to += branch["g_to"]
+            b_to += branch["b_to"]
+        end
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(p_to, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_to, -10.0*branch["mva_ub_nom"])
+
+        JuMP.set_upper_bound(p_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(p_to,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_to,  10.0*branch["mva_ub_nom"])
+
+        # From side of the branch flow
+        JuMP.@NLconstraint(model, p_fr ==  (g+g_fr)/ttm*vm_fr^2 + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-b*tr-g*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+        JuMP.@NLconstraint(model, q_fr == -(b+b_fr)/ttm*vm_fr^2 - (-b*tr-g*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+
+        # To side of the branch flow
+        JuMP.@NLconstraint(model, p_to ==  (g+g_to)*vm_to^2 + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-b*tr+g*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+        JuMP.@NLconstraint(model, q_to == -(b+b_to)*vm_to^2 - (-b*tr+g*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+
+        # Voltage angle difference limit
+        JuMP.@constraint(model, vad_lb <= va_fr - va_to <= vad_ub)
+
+        # Apparent power limit, from side and to side
+        JuMP.@constraint(model, p_fr^2 + q_fr^2 <= (branch["mva_ub_nom"])^2)
+        JuMP.@constraint(model, p_to^2 + q_to^2 <= (branch["mva_ub_nom"])^2)
+    end
+
+    for (uid,dc_line) in dc_line_lookup, i in periods
+        branch = dc_line
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        dc_line["pminf"] = -dc_line["pdc_ub"]
+        dc_line["pmaxf"] = dc_line["pdc_ub"]
+        dc_line["pmint"] = -dc_line["pdc_ub"]
+        dc_line["pmaxt"] = dc_line["pdc_ub"]
+
+        dc_line["qminf"] = dc_line["qdc_fr_lb"]
+        dc_line["qmaxf"] = dc_line["qdc_fr_ub"]
+        dc_line["qmint"] = dc_line["qdc_to_lb"]
+        dc_line["qmaxt"] = dc_line["qdc_to_ub"]
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -branch["pdc_ub"])
+        JuMP.set_lower_bound(q_fr,  branch["qdc_fr_lb"])
+        JuMP.set_lower_bound(p_to, -branch["pdc_ub"])
+        JuMP.set_lower_bound(q_to,  branch["qdc_to_lb"])
+
+        JuMP.set_upper_bound(p_fr, branch["pdc_ub"])
+        JuMP.set_upper_bound(q_fr, branch["qdc_fr_ub"])
+        JuMP.set_upper_bound(p_to, branch["pdc_ub"])
+        JuMP.set_upper_bound(q_to, branch["qdc_to_ub"])
+
+        # From side of the branch flow
+        JuMP.@constraint(model, p_fr + p_to == 0.0)
+    end
+
+    # Add ramping constraints
+    add_ramp_constraints!(model, sdd_lookup, periods, sdd_ids, dt;
+        p=p_sdd, u_on=on_status, u_su=u_su, u_sd=u_sd,
     )
 
     return model

--- a/src/power_curves.jl
+++ b/src/power_curves.jl
@@ -141,6 +141,11 @@ function get_contiguous_power_curves(input_data::NamedTuple; tolerance = 1e-8)
     return supc, p_supc, sdpc, p_sdpc
 end
 
+"""
+Returns u_su and u_sd indicators per the problem formulation. These are 1
+on the first interval after a SU curve or the first interval of an SD
+curve.
+"""
 function get_su_sd_from_on_status(input_data::NamedTuple, on_status::Dict)
     uids = input_data.sdd_ids
     periods = input_data.periods
@@ -170,6 +175,11 @@ function get_su_sd_from_on_status(input_data::NamedTuple, on_status::Dict)
     return u_su, u_sd
 end
 
+"""
+Returns indicators of whether we are in an SU/SD power curve and lookups
+of the corresponding SU/SD power. Note the difference between these indicators
+and u_su/u_sd from the problem formulation.
+"""
 function get_supc_sdpc_lookups(
     input_data::NamedTuple, on_status::Dict; tolerance = 1e-8
 )

--- a/src/scheduling_model.jl
+++ b/src/scheduling_model.jl
@@ -669,7 +669,11 @@ Constraints (102-103) and (112-113)
 """
 function add_reactive_power_implication_constraints!(
     model, input_data, T_su_pc, T_sd_pc;
-    include_reserves = false
+    include_reserves = false,
+    q=nothing,
+    u_on=nothing,
+    u_su=nothing,
+    u_sd=nothing,
 )
     sdd_ts_lookup = input_data.sdd_ts_lookup
     periods = input_data.periods
@@ -678,10 +682,18 @@ function add_reactive_power_implication_constraints!(
     sdd_ids_producer = input_data.sdd_ids_producer
     q_max = Dict(uid => sdd_ts_lookup[uid]["q_ub"] for uid in sdd_ids)
     q_min = Dict(uid => sdd_ts_lookup[uid]["q_lb"] for uid in sdd_ids)
-    q = model[:q]
-    u_on = model[:p_on_status]
-    u_su = model[:u_su]
-    u_sd = model[:u_sd]
+    if q === nothing
+        q = model[:q]
+    end
+    if u_on === nothing
+        u_on = model[:p_on_status]
+    end
+    if u_su === nothing
+        u_su = model[:u_su]
+    end
+    if u_sd === nothing
+        u_sd = model[:u_sd]
+    end
     if include_reserves
         q_qru = model[:q_qru]
         q_qrd = model[:q_qrd]

--- a/src/scheduling_model.jl
+++ b/src/scheduling_model.jl
@@ -469,24 +469,37 @@ Constraints (64-67)
 """
 function add_ramp_constraints!(
     model, sdd_lookup, periods, sdd_ids, dt;
+    p=nothing,
+    u_on=nothing,
+    u_su=nothing,
+    u_sd=nothing,
     tightening_fraction = 1.0
 )
+    if p === nothing
+        p = model[:p]
+    end
     # Note that this constraint doesn't need sdd_ts_lookup
     prev_p_lookup = Dict(
-        (uid, i) => (i == 1) ? sdd_lookup[uid]["initial_status"]["p"] : model[:p][uid, i-1]
+        (uid, i) => (i == 1) ? sdd_lookup[uid]["initial_status"]["p"] : p[uid, i-1]
         for uid in sdd_ids for i in periods
     )
     pjru = Dict(uid => sdd_lookup[uid]["p_ramp_up_ub"] for uid in sdd_ids)
     pjrd = Dict(uid => sdd_lookup[uid]["p_ramp_down_ub"] for uid in sdd_ids)
     pjrusu = Dict(uid => sdd_lookup[uid]["p_startup_ramp_ub"] for uid in sdd_ids)
     pjrdsd = Dict(uid => sdd_lookup[uid]["p_shutdown_ramp_ub"] for uid in sdd_ids)
-    u_on = model[:p_on_status]
-    u_su = model[:u_su]
-    u_sd = model[:u_sd]
+    if u_on === nothing
+        u_on = model[:p_on_status]
+    end
+    if u_su === nothing
+        u_su = model[:u_su]
+    end
+    if u_sd === nothing
+        u_sd = model[:u_sd]
+    end
     ramp_ub = @constraint(
         model,
         ramp_ub[uid in sdd_ids, i in periods],
-        model[:p][uid, i] - prev_p_lookup[uid, i] <= dt[i]*(
+        p[uid, i] - prev_p_lookup[uid, i] <= dt[i]*(
             tightening_fraction*pjru[uid]*(u_on[uid, i] - u_su[uid, i])
             + pjrusu[uid]*(u_su[uid, i] + 1 - u_on[uid, i])
         ),
@@ -494,7 +507,7 @@ function add_ramp_constraints!(
     ramp_lb = @constraint(
         model,
         ramp_lb[uid in sdd_ids, i in periods],
-        model[:p][uid, i] - prev_p_lookup[uid, i] >= -dt[i]*(
+        p[uid, i] - prev_p_lookup[uid, i] >= -dt[i]*(
             tightening_fraction*pjrd[uid]*u_on[uid, i] + pjrdsd[uid]*(1 - u_on[uid, i])
         ),
     )
@@ -506,17 +519,29 @@ Constraints (99-101) and (109-111)
 """
 function add_on_su_sd_implication_constraints!(
     model, input_data;
-    include_reserves = false
+    include_reserves = false,
+    p_on = nothing,
+    u_on = nothing,
+    p_su = nothing,
+    p_sd = nothing,
 )
     sdd_ts_lookup = input_data.sdd_ts_lookup
     periods = input_data.periods
     sdd_ids = input_data.sdd_ids
     sdd_ids_producer = input_data.sdd_ids_producer
     sdd_ids_consumer = input_data.sdd_ids_consumer
-    u_on = model[:p_on_status]
-    p_on = model[:p_on]
-    p_su = model[:p_su]
-    p_sd = model[:p_sd]
+    if u_on === nothing
+        u_on = model[:p_on_status]
+    end
+    if p_on === nothing
+        p_on = model[:p_on]
+    end
+    if p_su === nothing
+        p_su = model[:p_su]
+    end
+    if p_sd === nothing
+        p_sd = model[:p_sd]
+    end
     if include_reserves
         p_rgu = model[:p_rgu]
         p_rgd = model[:p_rgd]
@@ -722,7 +747,13 @@ Constraints (104-106) and (114-116)
 # TODO: These constraints will need to be updated (differentiate between
 # producers and consumers) when qrd/qru start being used.
 function add_real_reactive_linking_constraints!(
-    model, input_data, T_su_pc, T_sd_pc;
+    model,
+    input_data,
+    T_su_pc,
+    T_sd_pc;
+    pq = nothing,
+    u_on = nothing,
+    u_susd = nothing,
     include_reserves = false
 )
     sdd_lookup = input_data.sdd_lookup
@@ -745,11 +776,23 @@ function add_real_reactive_linking_constraints!(
     q_0 = Dict(uid => sdd_lookup[uid]["q_0"] for uid in pq_linear_sdds)
     beta = Dict(uid => sdd_lookup[uid]["beta"] for uid in pq_linear_sdds)
 
-    p = model[:p]
-    q = model[:q]
-    u_on = model[:p_on_status]
-    u_su = model[:u_su]
-    u_sd = model[:u_sd]
+    # Get default variables from model if not explicitly provided
+    if pq === nothing
+        p = model[:p]
+        q = model[:q]
+    else
+        p, q = pq
+    end
+    if u_on === nothing
+        u_on = model[:p_on_status]
+    end
+    if u_susd === nothing
+        u_su = model[:u_su]
+        u_sd = model[:u_sd]
+    else
+        u_su, u_sd = u_susd
+    end
+
     if include_reserves
         q_qru = model[:q_qru]
         q_qrd = model[:q_qrd]


### PR DESCRIPTION
A continuous-variable multiperiod ACOPF model, with binary on status variables fixed. The model may be constructed with `GOC3Benchmark.get_multiperiod_acopf_model(input_data, args=Dict("on_status" => on_status))`.

The model does not support all the features supported by the single-period ACOPF models. In particular, relaxing thermal constraints and relaxing-then-rounding shunts are not supported.