### PR TITLE
Option to construct full AC-UC model

### DIFF
--- a/src/GOC3Benchmark.jl
+++ b/src/GOC3Benchmark.jl
@@ -16,6 +16,8 @@ include("scheduler.jl")
 
 include("opf_model.jl")
 
+include("ac_uc_model.jl")
+
 include("process_bounds.jl")
 
 include("opf.jl")

--- a/src/ac_uc_model.jl
+++ b/src/ac_uc_model.jl
@@ -1,0 +1,647 @@
+import JuMP
+
+function get_ac_uc_model(
+    data::NamedTuple;
+    optimizer=nothing,
+    direct=false,
+    relax_balances=true, # Use slack for AC power balances
+    relax_p_balance=relax_balances,
+    relax_q_balance=relax_balances,
+    include_reserves=false,
+    fix_shunt_steps=true,
+    max_balance_violation=nothing,
+)
+    # Various other arguments, e.g. those to allow feasibility tests, may
+    # be useful eventually.
+    if optimizer === nothing
+        if direct
+            throw(ArgumentError("Direct model requires an optimizer"))
+        end
+        model = JuMP.Model()
+    elseif direct
+        model = JuMP.direct_model(optimizer)
+    else
+        model = JuMP.Model(optimizer)
+    end
+
+    # Data processing for unit commitment model
+    (
+     dt, periods, bus_lookup, bus_ids, shunt_lookup, shunt_ids, ac_line_lookup,
+     ac_line_ids, twt_lookup, twt_ids, dc_line_lookup, dc_line_ids, sdd_lookup,
+     sdd_ts_lookup, sdd_ids, sdd_ids_producer, sdd_ids_consumer, violation_cost,
+    ) = data
+    # Compute start, stop, and midpoint of each interval
+    interval_times = Vector{Any}()
+    start = 0.0
+    stop = 0.0
+    mid = 0.0
+    for (i, duration) in enumerate(dt)
+        start = stop
+        stop += duration
+        mid = 0.5*(start + stop)
+        push!(interval_times, (start=start, stop=stop, mid=mid))
+    end
+
+    # Data processing for ACOPF model
+    vad_ub = deg2rad(30)
+    vad_lb = -vad_ub
+    ac_on_status_dict = Dict(uid => [1 for _ in periods] for uid in ac_line_ids)
+    twt_on_status_dict = Dict(uid => [1 for _ in periods] for uid in twt_ids)
+
+    topo_data = preprocess_topology_data(data)
+    branch_fr_keys = topo_data.branch_fr_keys
+    branch_to_keys = topo_data.branch_to_keys
+    branch_keys = topo_data.branch_keys
+    bus_sdd_ids = topo_data.bus_sdd_ids
+    bus_sdd_producer_ids = topo_data.bus_sdd_producer_ids
+    bus_sdd_consumer_ids = topo_data.bus_sdd_consumer_ids
+    bus_shunt_ids = topo_data.bus_shunt_ids
+    bus_branch_keys = topo_data.bus_branch_keys
+
+    # Add scheduling model variables and constraints
+    p, q = add_power_variables!(model, sdd_ts_lookup, periods, sdd_ids)
+    p_on_status = add_p_on_status_variables!(model, sdd_ts_lookup, periods, sdd_ids)
+    mustrun_init, outage_init = add_init_mustrun_outage_constraints!(
+        model, sdd_lookup, periods, sdd_ids, interval_times
+    )
+    out = add_su_sd_variables_constraints!(
+        model, sdd_lookup, periods, sdd_ids
+    )
+    u_su, u_sd, on_status_evolution, prohibit_su_sd = out
+
+    min_up, min_dn = add_min_up_down_constraints!(
+        model, sdd_lookup, periods, sdd_ids, interval_times
+    )
+
+    max_starts_over_intervals = add_maximum_starts_over_intervals!(
+        model, sdd_lookup, periods, sdd_ids, interval_times
+    )
+    _, p_su_ru, _, p_sd_rd = get_contiguous_power_curves(data)
+    T_su_pc, T_sd_pc = get_inverse_power_curve_intervals(data)
+    p_su, p_sd, su_power_curve, sd_power_curve = add_startup_shutdown_power!(
+        model, sdd_ts_lookup, periods, sdd_ids, p_su_ru, T_su_pc, p_sd_rd, T_sd_pc
+    )
+    p_on, p_on_su_sd_aggregation = add_p_on_su_sd_aggregation!(
+        model, sdd_ts_lookup, sdd_ids, periods
+    )
+    ramp_ub, ramp_lb = add_ramp_constraints!(
+        model, sdd_lookup, periods, sdd_ids, dt
+    )
+    max_en_over_intervals, min_en_over_intervals = add_max_min_energy_over_intervals!(
+        model, sdd_lookup, periods, sdd_ids, interval_times, dt
+    )
+
+    # Add reserves, which are necessary for implication constraints if present
+    azr_ids = data.azr_ids
+    rzr_ids = data.rzr_ids
+    if include_reserves
+        reserve_vars = add_reserve_variables!(model, data)
+        (p_rgu, p_rgd, p_scr, p_nsc, p_rru_on, p_rrd_on, p_rru_off,
+         p_rrd_off, q_qru, q_qrd) = reserve_vars
+
+        res_costs = _get_reserve_costs(data)
+        (c_rgu, c_rgd, c_scr, c_nsc, c_rru_on, c_rrd_on, c_rru_off,
+         c_rrd_off, c_qru, c_qrd) = res_costs
+
+        res_shortfalls = add_reserve_shortfall_variables!(model, data)
+        (p_rgu_slack, p_rgd_slack, p_scr_slack, p_nsc_slack, p_rru_slack,
+         p_rrd_slack, q_qru_slack, q_qrd_slack) = res_shortfalls
+
+        res_penalties = _get_reserve_shortfall_penalties(data)
+        z_rgu, z_rgd, z_scr, z_nsc, z_rru, z_rrd, z_qru, z_qrd = res_penalties
+
+        add_reserve_balances!(
+            # Note we are relaxing reserves here. This will change if we support
+            # solving reserve-feasibility problems.
+            model, data, model[:p]; relax = true
+        )
+
+        # Reserve cost expressions
+        @expression(model,
+            c_rgu_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rgu[uid][i] * p_rgu[uid, i]
+        )
+        @expression(model,
+            c_rgd_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rgd[uid][i] * p_rgd[uid, i]
+        )
+        @expression(model,
+            c_scr_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_scr[uid][i] * p_scr[uid, i]
+        )
+        @expression(model,
+            c_nsc_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_nsc[uid][i] * p_nsc[uid, i]
+        )
+        @expression(model,
+            c_rru_on_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rru_on[uid][i] * p_rru_on[uid, i]
+        )
+        @expression(model,
+            c_rrd_on_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rrd_on[uid][i] * p_rrd_on[uid, i]
+        )
+        @expression(model,
+            c_rru_off_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rru_off[uid][i] * p_rru_off[uid, i]
+        )
+        @expression(model,
+            c_rrd_off_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_rrd_off[uid][i] * p_rrd_off[uid, i]
+        )
+        @expression(model,
+            c_qru_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_qru[uid][i] * q_qru[uid, i]
+        )
+        @expression(model,
+            c_qrd_expr[uid in sdd_ids, i in periods],
+            dt[i] * c_qrd[uid][i] * q_qrd[uid, i]
+        )
+
+        # Reserve shortfall penalty expressions
+        # Active zonal reserves
+        @expression(model,
+            rgu_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_rgu[uid] * p_rgu_slack[uid, i]
+        )
+        @expression(model,
+            rgd_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_rgd[uid] * p_rgd_slack[uid, i]
+        )
+        @expression(model,
+            scr_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_scr[uid] * p_scr_slack[uid, i]
+        )
+        @expression(model,
+            nsc_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_nsc[uid] * p_nsc_slack[uid, i]
+        )
+        @expression(model,
+            rru_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_rru[uid] * p_rru_slack[uid, i]
+        )
+        @expression(model,
+            rrd_sf_expr[uid in azr_ids, i in periods],
+            dt[i] * z_rrd[uid] * p_rrd_slack[uid, i]
+        )
+        # Reactive zonal reserves
+        @expression(model,
+            qru_sf_expr[uid in rzr_ids, i in periods],
+            dt[i] * z_qru[uid] * q_qru_slack[uid, i]
+        )
+        @expression(model,
+            qrd_sf_expr[uid in rzr_ids, i in periods],
+            dt[i] * z_qrd[uid] * q_qrd_slack[uid, i]
+        )
+
+    else
+        # If reserves are not included, create dummy expressions to use in the
+        # objective function without more nested branching.
+        @expression(model, c_rgu_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_rgd_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_scr_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_nsc_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_rru_on_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_rrd_on_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_rru_off_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_rrd_off_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_qru_expr[uid in sdd_ids, i in periods], 0.0)
+        @expression(model, c_qrd_expr[uid in sdd_ids, i in periods], 0.0)
+
+        @expression(model, rgu_sf_expr[uid in azr_ids, i in periods], 0.0)
+        @expression(model, rgd_sf_expr[uid in azr_ids, i in periods], 0.0)
+        @expression(model, scr_sf_expr[uid in azr_ids, i in periods], 0.0)
+        @expression(model, nsc_sf_expr[uid in azr_ids, i in periods], 0.0)
+        @expression(model, rru_sf_expr[uid in azr_ids, i in periods], 0.0)
+        @expression(model, rrd_sf_expr[uid in azr_ids, i in periods], 0.0)
+
+        @expression(model, qru_sf_expr[uid in rzr_ids, i in periods], 0.0)
+        @expression(model, qrd_sf_expr[uid in rzr_ids, i in periods], 0.0)
+    end
+
+    add_on_su_sd_implication_constraints!(
+        model, data; include_reserves = include_reserves
+    )
+    add_reactive_power_implication_constraints!(
+        model, data, T_su_pc, T_sd_pc; include_reserves = include_reserves
+    )
+    add_real_reactive_linking_constraints!(
+        model, data, T_su_pc, T_sd_pc; include_reserves = include_reserves
+    )
+
+    on_status = model[:p_on_status]
+
+    # TODO: Insert AC variables and equations here
+    # Will need to audit all the constraints being added to make sure they still
+    # make sense in this version of the model. Major differences are:
+    # - This model has distinct p_on/p_su/p_sd variables
+    # - on_status is a variable
+    # - u_su and u_sd are variables
+    # - We are including reserves
+    #
+    # Any constraints I will need to add that were not relevant before?
+    @variable(model, bus_lookup[uid]["vm_lb"] <= vm[uid in bus_ids, t in periods] <= bus_lookup[uid]["vm_ub"], start=1.0)
+    @variable(model, va[uid in bus_ids, t in periods])
+
+    # Note that device p/q variables are already defined
+
+    @variable(model, p_branch[uid in branch_keys, t in periods])
+    @variable(model, q_branch[uid in branch_keys, t in periods])
+    # TODO: Support thermal limit relaxation if necessary
+    #if relax_thermal_limits
+    #    @variable(model, ac_thermal_slack[uid in ac_line_ids, t in periods] >= 0.0)
+    #    @variable(model, twt_thermal_slack[uid in twt_ids, t in periods] >= 0.0)
+    #end
+
+    # Cost blocks for objective
+    cost_blocks, cost_block_p, p_disagg, device_cost = add_device_power_cost!(
+        model, sdd_ts_lookup, periods, sdd_ids 
+    )
+    cost_by_period = @expression(
+        model,
+        cost_by_period[i=periods],
+        sum(device_cost[uid, i] for uid in sdd_ids_consumer) -
+        sum(device_cost[uid, i] for uid in sdd_ids_producer)
+    )
+
+    @variable(
+        model,
+        shunt_lookup[uid]["step_lb"]
+        <= shunt_step[uid in shunt_ids, i in periods]
+        <= shunt_lookup[uid]["step_ub"]
+    )
+    if fix_shunt_steps
+        for uid in shunt_ids
+            init_step = shunt_lookup[uid]["initial_status"]["step"]
+            JuMP.fix.(shunt_step[uid, :], init_step, force = true)
+        end
+    end
+
+    # Add slack variables for power balance relaxation (which we usually use)
+    if relax_p_balance
+        if max_balance_violation !== nothing
+            p_balance_slack_pos = @variable(
+                model,
+                0 <= p_balance_slack_pos[bus_ids, periods] <= max_balance_violation,
+            )
+            p_balance_slack_neg = @variable(
+                model,
+                0 <= p_balance_slack_neg[bus_ids, periods] <= max_balance_violation,
+            )
+        else
+            p_balance_slack_pos = @variable(model, 0 <= p_balance_slack_pos[bus_ids, periods])
+            p_balance_slack_neg = @variable(model, 0 <= p_balance_slack_neg[bus_ids, periods])
+        end
+        p_balance_penalty = violation_cost["p_bus_vio_cost"]
+    end
+    if relax_q_balance
+        if max_balance_violation !== nothing
+            q_balance_slack_pos = @variable(
+                model,
+                0 <= q_balance_slack_pos[bus_ids, periods] <= max_balance_violation,
+            )
+            q_balance_slack_neg = @variable(
+                model,
+                0 <= q_balance_slack_neg[bus_ids, periods] <= max_balance_violation,
+            )
+        else
+            q_balance_slack_pos = @variable(model, 0 <= q_balance_slack_pos[bus_ids, periods])
+            q_balance_slack_neg = @variable(model, 0 <= q_balance_slack_neg[bus_ids, periods])
+        end
+        q_balance_penalty = violation_cost["q_bus_vio_cost"]
+    end
+
+    # Arbitrarily fix voltage angle for a reference bus
+    for (uid, bus) in bus_lookup
+        @constraint(model, [i in periods], va[uid, i] == 0.0)
+        break
+    end
+
+    # Create penalty terms for power balance violations
+    if relax_p_balance
+        p_balance_penalty_term = @expression(model,
+            [i in periods],
+            p_balance_penalty*sum(
+                p_balance_slack_pos[uid, i] + p_balance_slack_neg[uid, i]
+                for uid in bus_ids,
+                init = 0
+            )
+        )
+    else
+        p_balance_penalty_term = 0.0
+    end
+    if relax_q_balance
+        q_balance_penalty_term = @expression(model,
+            [i in periods],
+            q_balance_penalty*sum(
+                q_balance_slack_pos[uid, i] + q_balance_slack_neg[uid, i]
+                for uid in bus_ids,
+                init = 0
+            )
+        )
+    else
+        q_balance_penalty_term = 0.0
+    end
+    # TODO: Thermal limit penalty expressions?
+    # (Only if I allow relaxing these constraints.)
+
+    on_cost, su_cost, sd_cost = add_on_su_sd_cost!(model, data)
+
+    # TODO: Add penalty terms for AC slack variables
+    # This may be considered "base operating cost". We will add to this
+    # the reserve operating cost, and the penalties we incur for not satisfying
+    # zonal reserve requirements and AC power balances.
+    cost_expr = @expression(model,
+        cost_expr,
+        sum(dt[i]*cost_by_period[i] for i in periods)
+        - on_cost - su_cost - sd_cost
+    )
+    reserve_cost_expr = @expression(model,
+        reserve_cost_expr,
+        # Reserve cost expressions
+        # If reserves are not included, these are zero. Note that these have
+        # already been multiplied by dt.
+        - sum(c_rgu_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_rgd_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_scr_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_nsc_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_rru_on_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_rrd_on_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_rru_off_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_rrd_off_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_qru_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+        - sum(c_qrd_expr[uid, i] for uid in sdd_ids for i in periods, init = 0)
+    )
+
+    @objective(model,
+        Max,
+        # These are zero if we are only penalizing reserve shortfall
+        cost_expr + reserve_cost_expr
+        # Reserve shortfall expressions
+        # If reserves are not included, these are zero. Note that these have
+        # already been multiplied by dt.
+        # Active
+        - sum(rgu_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        - sum(rgd_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        - sum(scr_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        - sum(nsc_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        - sum(rru_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        - sum(rrd_sf_expr[uid, i] for uid in azr_ids for i in periods, init = 0)
+        # Reactive
+        - sum(qru_sf_expr[uid, i] for uid in rzr_ids for i in periods, init = 0)
+        - sum(qrd_sf_expr[uid, i] for uid in rzr_ids for i in periods, init = 0)
+        - sum(
+            dt[t] * (p_balance_penalty_term[t] + q_balance_penalty_term[t])
+            for t in periods
+        )
+    )
+
+    # Define aliases for p and q using the variable names we used in the OPF model
+    p_sdd = p
+    q_sdd = q
+
+    if relax_p_balance
+        @NLconstraint(model,
+            p_balance[uid in bus_ids, i in periods],
+            sum(p_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) -
+            sum(
+                shunt_lookup[shunt_id]["gs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #gs*vm[uid]^2
+            # Add positive and negative slack variables
+            + (p_balance_slack_pos[uid, i] - p_balance_slack_neg[uid, i])
+        )
+    else
+        @NLconstraint(model,
+            p_balance[uid in bus_ids, i in periods],
+            sum(p_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(p_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) -
+            sum(
+                shunt_lookup[shunt_id]["gs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #gs*vm[uid]^2
+        )
+    end
+    if relax_q_balance
+        @NLconstraint(model,
+            q_balance[uid in bus_ids, i in periods],
+            sum(q_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) +
+            sum(
+                shunt_lookup[shunt_id]["bs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #bs*vm[uid]^2
+            # Add positive and negative slack variables
+            + (q_balance_slack_pos[uid, i] - q_balance_slack_neg[uid, i])
+        )
+    else
+        @NLconstraint(model, 
+            q_balance[uid in bus_ids, i in periods],
+            sum(q_branch[k, i] for k in bus_branch_keys[uid], init = 0) ==
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_producer_ids[uid], init = 0) -
+            sum(q_sdd[ssd_id, i] for ssd_id in bus_sdd_consumer_ids[uid], init = 0) +
+            sum(
+                shunt_lookup[shunt_id]["bs"]*shunt_step[shunt_id, i]
+                for shunt_id in bus_shunt_ids[uid],
+                init = 0
+            )*vm[uid, i]^2
+            #bs*vm[uid]^2
+        )
+    end
+
+    for (uid,ac_line) in ac_line_lookup, i in periods
+        branch = ac_line
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        #if relax_thermal_limits
+        #    s_thermal = ac_thermal_slack[uid]
+        #else
+        #    s_thermal = 0.0
+        #end
+
+        vm_fr = vm[branch["fr_bus"], i]
+        vm_to = vm[branch["to_bus"], i]
+        va_fr = va[branch["fr_bus"], i]
+        va_to = va[branch["to_bus"], i]
+
+        r = branch["r"]
+        x = branch["x"]
+        y = 1 / (r + im*x)
+        g = real(y)
+        b = imag(y)
+
+        tm = 1.0
+        ta = 0.0
+        tr = tm * cos(ta)
+        ti = tm * sin(ta)
+        ttm = tm^2
+
+        g_fr = 0.0
+        b_fr = branch["b"]/2.0
+        g_to = 0.0
+        b_to = branch["b"]/2.0
+
+        if branch["additional_shunt"] == 1
+            g_fr += branch["g_fr"]
+            b_fr += branch["b_fr"]
+            g_to += branch["g_to"]
+            b_to += branch["b_to"]
+        end
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(p_to, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_to, -10.0*branch["mva_ub_nom"])
+
+        JuMP.set_upper_bound(p_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(p_to,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_to,  10.0*branch["mva_ub_nom"])
+
+        # From side of the branch flow
+        JuMP.@NLconstraint(model, p_fr ==  (g+g_fr)/ttm*vm_fr^2 + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-b*tr-g*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+        JuMP.@NLconstraint(model, q_fr == -(b+b_fr)/ttm*vm_fr^2 - (-b*tr-g*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+
+        # To side of the branch flow
+        JuMP.@NLconstraint(model, p_to ==  (g+g_to)*vm_to^2 + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-b*tr+g*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+        JuMP.@NLconstraint(model, q_to == -(b+b_to)*vm_to^2 - (-b*tr+g*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+
+        # Voltage angle difference limit
+        JuMP.@constraint(model, vad_lb <= va_fr - va_to <= vad_ub)
+
+        # Apparent power limit, from side and to side
+        # TODO: What is the best way to formulate this as a soft constraint?
+        # Square root? Or (s_max + slack)^2?
+        # TODO: Potentially re-add option to relax
+        JuMP.@constraint(model, p_fr^2 + q_fr^2 <= (branch["mva_ub_nom"])^2)
+        JuMP.@constraint(model, p_to^2 + q_to^2 <= (branch["mva_ub_nom"])^2)
+    end
+
+    for (uid,twt) in twt_lookup, i in periods
+        branch = twt
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        #if relax_thermal_limits
+        #    s_thermal = twt_thermal_slack[uid]
+        #else
+        #    s_thermal = 0.0
+        #end
+
+        vm_fr = vm[branch["fr_bus"], i]
+        vm_to = vm[branch["to_bus"], i]
+        va_fr = va[branch["fr_bus"], i]
+        va_to = va[branch["to_bus"], i]
+
+        r = branch["r"]
+        x = branch["x"]
+        y = 1 / (r + im*x)
+        g = real(y)
+        b = imag(y)
+
+        initial_status = branch["initial_status"]
+
+        tm = initial_status["tm"]
+        ta = initial_status["ta"]
+        tr = tm * cos(ta)
+        ti = tm * sin(ta)
+        ttm = tm^2
+
+        g_fr = 0.0
+        b_fr = branch["b"]/2.0
+        g_to = 0.0
+        b_to = branch["b"]/2.0
+
+        if branch["additional_shunt"] == 1
+            g_fr += branch["g_fr"]
+            b_fr += branch["b_fr"]
+            g_to += branch["g_to"]
+            b_to += branch["b_to"]
+        end
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_fr, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(p_to, -10.0*branch["mva_ub_nom"])
+        JuMP.set_lower_bound(q_to, -10.0*branch["mva_ub_nom"])
+
+        JuMP.set_upper_bound(p_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_fr,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(p_to,  10.0*branch["mva_ub_nom"])
+        JuMP.set_upper_bound(q_to,  10.0*branch["mva_ub_nom"])
+
+        # From side of the branch flow
+        JuMP.@NLconstraint(model, p_fr ==  (g+g_fr)/ttm*vm_fr^2 + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-b*tr-g*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+        JuMP.@NLconstraint(model, q_fr == -(b+b_fr)/ttm*vm_fr^2 - (-b*tr-g*ti)/ttm*(vm_fr*vm_to*cos(va_fr-va_to)) + (-g*tr+b*ti)/ttm*(vm_fr*vm_to*sin(va_fr-va_to)) )
+
+        # To side of the branch flow
+        JuMP.@NLconstraint(model, p_to ==  (g+g_to)*vm_to^2 + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-b*tr+g*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+        JuMP.@NLconstraint(model, q_to == -(b+b_to)*vm_to^2 - (-b*tr+g*ti)/ttm*(vm_to*vm_fr*cos(va_to-va_fr)) + (-g*tr-b*ti)/ttm*(vm_to*vm_fr*sin(va_to-va_fr)) )
+
+        # Voltage angle difference limit
+        JuMP.@constraint(model, vad_lb <= va_fr - va_to <= vad_ub)
+
+        # Apparent power limit, from side and to side
+        JuMP.@constraint(model, p_fr^2 + q_fr^2 <= (branch["mva_ub_nom"])^2)
+        JuMP.@constraint(model, p_to^2 + q_to^2 <= (branch["mva_ub_nom"])^2)
+    end
+
+    for (uid,dc_line) in dc_line_lookup, i in periods
+        branch = dc_line
+        fr_key = (uid, branch["fr_bus"], branch["to_bus"])
+        to_key = (uid, branch["to_bus"], branch["fr_bus"])
+
+        p_fr = p_branch[fr_key, i]
+        q_fr = q_branch[fr_key, i]
+        p_to = p_branch[to_key, i]
+        q_to = q_branch[to_key, i]
+
+        dc_line["pminf"] = -dc_line["pdc_ub"]
+        dc_line["pmaxf"] = dc_line["pdc_ub"]
+        dc_line["pmint"] = -dc_line["pdc_ub"]
+        dc_line["pmaxt"] = dc_line["pdc_ub"]
+
+        dc_line["qminf"] = dc_line["qdc_fr_lb"]
+        dc_line["qmaxf"] = dc_line["qdc_fr_ub"]
+        dc_line["qmint"] = dc_line["qdc_to_lb"]
+        dc_line["qmaxt"] = dc_line["qdc_to_ub"]
+
+        # variable bounds
+        JuMP.set_lower_bound(p_fr, -branch["pdc_ub"])
+        JuMP.set_lower_bound(q_fr,  branch["qdc_fr_lb"])
+        JuMP.set_lower_bound(p_to, -branch["pdc_ub"])
+        JuMP.set_lower_bound(q_to,  branch["qdc_to_lb"])
+
+        JuMP.set_upper_bound(p_fr, branch["pdc_ub"])
+        JuMP.set_upper_bound(q_fr, branch["qdc_fr_ub"])
+        JuMP.set_upper_bound(p_to, branch["pdc_ub"])
+        JuMP.set_upper_bound(q_to, branch["qdc_to_ub"])
+
+        # From side of the branch flow
+        JuMP.@constraint(model, p_fr + p_to == 0.0)
+    end
+
+    return model
+end

--- a/src/ac_uc_solver.jl
+++ b/src/ac_uc_solver.jl
@@ -72,6 +72,13 @@ function run_ac_uc_solver(args::Dict)
     print_projected_devices = get(args, "print_projected_devices", true)
     print_violated_qbalance = get(args, "print_violated_qbalance", false)
 
+    simultaneous_acuc = get(args, "simultaneous_acuc", false)
+    include_reserves_in_acuc = get(args, "include_reserves_in_acuc", false)
+    minlp_optimizer = get(args, "minlp_optimizer", nothing)
+    if simultaneous_acuc && minlp_optimizer === nothing
+        throw(ArgumentError("minlp_optimizer must be provided if simultaneous_acuc is used"))
+    end
+
     #
     # Options for MIP solve
     #
@@ -179,262 +186,38 @@ function run_ac_uc_solver(args::Dict)
 
     timing_data["load_initial_data"] = time() - start_time
 
-    time_mip_start = time()
-
-    if warmstart_mip
-        # Note that this simply copies initial status and does not solve
-        # a MIP
-        naive_schedule = schedule_to_initial_point(input_data)
-    else
-        naive_schedule = nothing
-    end
-
-    if schedule_independently
-        model, schedule_data = schedule_power_independently(
-            input_data;
-            optimizer = mip_optimizer,
-            relax_integrality = relax_integrality,
-            time_limit = scheduler_time_limit,
-            include_reserves = include_reserves_in_schedule,
-            warmstart_data = naive_schedule,
-        )
-    elseif schedule_close_to_initial
-        model, schedule_data = schedule_close_to_initial_point(
-            input_data;
-            optimizer = mip_optimizer,
-            relax_integrality = relax_integrality,
-            time_limit = scheduler_time_limit,
-        )
-    else
-        # If we were not told to schedule independently, we schedule
-        # with a 2-step procedure, where we first try with a strict
-        # copper-plate balance, then with a relaxed copperplate balance
-        # with penalized violation.
-        #
-        # Determine a valid generation/consumption schedule assuming a
-        # copper-plate grid
-        #
-        model, schedule_data = schedule_power_copperplate(
-            input_data;
-            optimizer = mip_optimizer,
-            relax_integrality = relax_integrality,
-            time_limit = scheduler_time_limit,
-            relax_balances = relax_copperplate_balances,
-            include_reserves = include_reserves_in_schedule,
-            warmstart_data = naive_schedule,
-            overcommitment_factor = overcommitment_factor,
-        )
-        if schedule_data === nothing && !relax_copperplate_balances
-            # If we can't find a feasible solution within the time limit, AND
-            # we did not already relax the copperplate balances, relax the
-            # copperplate balances and try again.
-            # We may need to provide or determine a different time limit for this
-            # solve.
-            model, schedule_data = schedule_power_copperplate(
-                input_data;
-                optimizer = mip_optimizer,
-                relax_integrality = relax_integrality,
-                time_limit = scheduler_time_limit,
-                relax_balances = true,
-                include_reserves = include_reserves_in_schedule,
-                warmstart_data = naive_schedule,
-                overcommitment_factor = overcommitment_factor,
-            )
-        end
-    end
-    if schedule_data === nothing
-        # If the scheduling procedure above (independent or otherwise) fails,
-        # we simply copy scheduling decisions from the initial point to try and
-        # write *some* solution file.
-        schedule_data = schedule_to_initial_point(input_data)
-    end
-    pr_status = primal_status(model)
-    feasible_schedule = (pr_status == FEASIBLE_POINT)
-
-    if feasible_schedule
-        solve_data["feasible"] = true
-        solve_data["objective_value"] = objective_value(model)
-    else
-        solve_data["feasible"] = false
-        if halt_on_infeasible_schedule
-            # TODO: Find a place for this useful code
-            #compute_conflict!(model)
-            #println("Constraints in conflict:")
-            #for con in all_constraints(model, include_variable_in_set_constraints=true)
-            #    status = MOI.get(model, MOI.ConstraintConflictStatus(), con)
-            #    if status == MOI.IN_CONFLICT
-            #        println(con)
-            #    end
-            #end
-            return solve_data
-        end
-    end
-
-    # All the conditions required for schedule_data to have reserves
-    if (
-        include_reserves_in_schedule
-        && feasible_schedule
-        && !schedule_close_to_initial
-        && sdd_fraction_to_constrain > 0.0
-    )
-        pos_reserve_value, neg_reserve_value = compute_device_reserve_values(input_data, schedule_data)
-
-        topo_data = preprocess_topology_data(input_data)
-        sdd2bus = Dict()
-        for bus_id in input_data.bus_ids
-            for sdd_id in topo_data.bus_sdd_ids[bus_id]
-                sdd2bus[sdd_id] = bus_id
-            end
-        end
-        has_shunt = Dict(uid => (length(topo_data.bus_shunt_ids[sdd2bus[uid]]) >= 1) for uid in input_data.sdd_ids)
-
-        println("Computing costs for fixing devices")
-        # Estimate of (local) power balance violation penalty we will take by
-        # *preventing the device from decreasing*
-        balance_costs = compute_device_balance_costs(input_data, schedule_data, allow_switching = allow_switching)
-        println("Done computing costs")
-
-        net_value_for_lb = Dict(uid => (neg_reserve_value[uid] - balance_costs[uid]) for uid in input_data.sdd_ids)
-        net_value_for_ub = Dict(uid => (pos_reserve_value[uid] - balance_costs[uid]) for uid in input_data.sdd_ids)
-
-        sdd_by_ub_value = sort(input_data.sdd_ids, by = uid -> net_value_for_ub[uid], rev = true)
-        sdd_by_lb_value = sort(input_data.sdd_ids, by = uid -> net_value_for_lb[uid], rev = true)
-        sdd_by_ub_pos = [uid for uid in sdd_by_ub_value if net_value_for_ub[uid] > 0 && balance_costs[uid] == 0 && !has_shunt[uid]]
-        sdd_by_lb_pos = [uid for uid in sdd_by_lb_value if net_value_for_lb[uid] > 0 && balance_costs[uid] == 0 && !has_shunt[uid]]
-
-        n_to_ub = Int64(round(sdd_fraction_to_constrain * length(sdd_by_ub_pos)))
-        n_to_lb = Int64(round(sdd_fraction_to_constrain * length(sdd_by_lb_pos)))
-
-        sdd_to_ub = sdd_by_ub_pos[1:n_to_ub]
-        sdd_to_lb = sdd_by_lb_pos[1:n_to_lb]
-
-        println("SDD TO BE UPPER BOUNDED THROUGHOUT OPF SOLVES")
-        println("---------------------------------------------")
-        for (i, uid) in enumerate(sdd_to_ub)
-            println("$i: uid=$uid, reserve value = $(pos_reserve_value[uid]), balance cost = $(balance_costs[uid]), net value = $(net_value_for_ub[uid])")
-        end
-        println("---------------------------------------------")
-        println("SDD TO BE LOWER BOUNDED THROUGHOUT OPF SOLVES")
-        println("---------------------------------------------")
-        for (i, uid) in enumerate(sdd_to_lb)
-            println("$i: uid=$uid, reserve value = $(neg_reserve_value[uid]), balance cost = $(balance_costs[uid]), net value = $(net_value_for_lb[uid])")
-        end
-        println("---------------------------------------------")
-    else
-        sdd_to_ub = []
-        sdd_to_lb = []
-    end
-
-    timing_data["schedule_total"] = time() - time_mip_start
-
-    time_opf_start = time()
-
-    on_status = schedule_data.on_status
-    real_power = schedule_data.real_power
-
-    if tighten_bounds_pre_opf && feasible_schedule
-        # Only tighten bounds if we have a feasible schedule. Otherwise bounds
-        # can cross, and we don't handle that case here.
-        processed_data = tighten_bounds_using_ramp_limits(
-            input_data, on_status, real_power
-        )
-    else
-        processed_data = input_data
-    end
-
-    #
-    # Solve ACOPF problem for every time period
-    #
-    if parallel_opf
-        # First, compute in parallel
-        acopf_solutions = compute_opf_in_parallel(
-            processed_data,
-            on_status,
-            real_power;
-            optimizer = nlp_optimizer,
-            ipopt_linear_solver = linear_solver,
-            fix_real_power = fix_ac_real_power,
-            penalize_power_deviation = true,
-            allow_switching = allow_switching,
-            resolve_rounded_shunts = resolve_rounded_shunts,
-            fix_shunt_steps = !resolve_rounded_shunts,
-            relax_thermal_limits = relax_thermal_limits,
-            sdd_to_lb = sdd_to_lb,
-            sdd_to_ub = sdd_to_ub,
-        )
-
-        acopf_solve_data = [data for (_, data) in acopf_solutions]
-        #
-        # Construct serializable solution data structure
-        #
-        solfile_dict = construct_solution_dict(
-            input_data,
-            schedule_data;
-            opf_data = acopf_solve_data,
-            write_duals = write_duals,
-            include_reserves = true,
-            # We need postprocessing after the parallel solves to make sure that
-            # ramping constraints are satisfied.
-            #
-            # TODO: Why is postprocessing combined with construction of the
-            # solution data structure? Just to make this function simpler?
-            postprocess = true,
-            print_projected_devices = print_projected_devices,
-        )
-
-        #
-        # Write out solution file
-        #
-        if "solution_file" in keys(args)
-            solution_fpath = args["solution_file"]
-            # Defer making the solution file directory until now so that we hopefully
-            # only make this directory if we are going to put something in it.
-            mkpath(dirname(solution_fpath))
-            open(io -> JSON.print(io, solfile_dict, 4), solution_fpath, "w")
-            println("Wrote solution file at $(time() - start_time) s")
-            println("(after start of run_ac_uc_solver)")
-        end
-
-        #
-        # Now, if we used a parallel, fully-independent solve previously, we
-        # re-solve with sequential OPF solves to try to achieve a better solution
-        # than the solve-independently-and-project solution gives us.
-        #
-        if post_parallel_sequential
-            acopf_solutions = compute_optimal_power_flows(
-                processed_data,
-                on_status,
-                real_power;
-                # In this post-parallel solve, we always solve sequentially.
-                sequential = true,
-                optimizer = nlp_optimizer,
-                ipopt_linear_solver = linear_solver,
-                fix_real_power = fix_ac_real_power,
-                penalize_power_deviation = true,
-                allow_switching = allow_switching,
-                resolve_rounded_shunts = resolve_rounded_shunts,
-                fix_shunt_steps = !resolve_rounded_shunts,
-                relax_thermal_limits = relax_thermal_limits,
-                sdd_to_lb = sdd_to_lb,
-                sdd_to_ub = sdd_to_ub,
-            )
-        end
-    elseif multiperiod_opf
+    if simultaneous_acuc
         if fix_ac_real_power
-            throw(ArgumentError("multiperiod_opf cannot be used with fix_ac_real_power"))
+            throw(ArgumentError("simultaneous_acuc cannot be used with fix_ac_real_power"))
         end
         if resolve_rounded_shunts
-            throw(ArgumentError("multiperiod_opf does not support re-solving shunts yet"))
+            throw(ArgumentError("simultaneous_acuc does not support re-solving shunts yet"))
         end
         if relax_thermal_limits
-            throw(ArgumentError("multiperiod_opf does not support relax_thermal_limits"))
+            throw(ArgumentError("simultaneous_acuc does not support relax_thermal_limits"))
         end
-        _, mpacopf_solution = compute_multiperiod_opf(
-            processed_data,
-            on_status;
-            optimizer = nlp_optimizer,
-            ipopt_linear_solver = linear_solver,
-            return_model = false,
+        acuc_model = get_ac_uc_model(
+            input_data,
+            include_reserves=include_reserves_in_acuc,
+        )
+        JuMP.set_optimizer(acuc_model, minlp_optimizer)
+        JuMP.optimize!(acuc_model)
+
+        # We can extract scheduling data easily as this model uses the same
+        # variable names as the full model
+        schedule_data = extract_data_from_scheduling_model(
+            input_data,
+            acuc_model,
+            include_reserves=include_reserves_in_acuc,
+        )
+        # We should be able to extract OPF data by simply overriding the default
+        # variable names used for p and q
+        mpacopf_solution = extract_data_from_multiperiod_model(
+            acuc_model,
+            input_data,
+            schedule_data.on_status,
+            p_sdd=acuc_model[:p],
+            q_sdd=acuc_model[:q],
         )
         # Reshape the solution data for consistency with other subroutines
         acopf_solutions = [
@@ -447,26 +230,297 @@ function run_ac_uc_solver(args::Dict)
             )) for i in periods
         ]
     else
-        # This is a non-parallel default. It can solve OPF subproblems
-        # independently or sequentially. This is controlled by the sequential_opf
-        # option.
-        acopf_solutions = compute_optimal_power_flows(
-            processed_data,
-            on_status,
-            real_power;
-            sequential = sequential_opf,
-            optimizer = nlp_optimizer,
-            ipopt_linear_solver = linear_solver,
-            fix_real_power = fix_ac_real_power,
-            penalize_power_deviation = true,
-            allow_switching = allow_switching,
-            resolve_rounded_shunts = resolve_rounded_shunts,
-            fix_shunt_steps = !resolve_rounded_shunts,
-            relax_thermal_limits = relax_thermal_limits,
-            sdd_to_lb = sdd_to_lb,
-            sdd_to_ub = sdd_to_ub,
+        time_mip_start = time()
+
+        if warmstart_mip
+            # Note that this simply copies initial status and does not solve
+            # a MIP
+            naive_schedule = schedule_to_initial_point(input_data)
+        else
+            naive_schedule = nothing
+        end
+
+        if schedule_independently
+            model, schedule_data = schedule_power_independently(
+                input_data;
+                optimizer = mip_optimizer,
+                relax_integrality = relax_integrality,
+                time_limit = scheduler_time_limit,
+                include_reserves = include_reserves_in_schedule,
+                warmstart_data = naive_schedule,
+            )
+        elseif schedule_close_to_initial
+            model, schedule_data = schedule_close_to_initial_point(
+                input_data;
+                optimizer = mip_optimizer,
+                relax_integrality = relax_integrality,
+                time_limit = scheduler_time_limit,
+            )
+        else
+            # If we were not told to schedule independently, we schedule
+            # with a 2-step procedure, where we first try with a strict
+            # copper-plate balance, then with a relaxed copperplate balance
+            # with penalized violation.
+            #
+            # Determine a valid generation/consumption schedule assuming a
+            # copper-plate grid
+            #
+            model, schedule_data = schedule_power_copperplate(
+                input_data;
+                optimizer = mip_optimizer,
+                relax_integrality = relax_integrality,
+                time_limit = scheduler_time_limit,
+                relax_balances = relax_copperplate_balances,
+                include_reserves = include_reserves_in_schedule,
+                warmstart_data = naive_schedule,
+                overcommitment_factor = overcommitment_factor,
+            )
+            if schedule_data === nothing && !relax_copperplate_balances
+                # If we can't find a feasible solution within the time limit, AND
+                # we did not already relax the copperplate balances, relax the
+                # copperplate balances and try again.
+                # We may need to provide or determine a different time limit for this
+                # solve.
+                model, schedule_data = schedule_power_copperplate(
+                    input_data;
+                    optimizer = mip_optimizer,
+                    relax_integrality = relax_integrality,
+                    time_limit = scheduler_time_limit,
+                    relax_balances = true,
+                    include_reserves = include_reserves_in_schedule,
+                    warmstart_data = naive_schedule,
+                    overcommitment_factor = overcommitment_factor,
+                )
+            end
+        end
+        if schedule_data === nothing
+            # If the scheduling procedure above (independent or otherwise) fails,
+            # we simply copy scheduling decisions from the initial point to try and
+            # write *some* solution file.
+            schedule_data = schedule_to_initial_point(input_data)
+        end
+        pr_status = primal_status(model)
+        feasible_schedule = (pr_status == FEASIBLE_POINT)
+
+        if feasible_schedule
+            solve_data["feasible"] = true
+            solve_data["objective_value"] = objective_value(model)
+        else
+            solve_data["feasible"] = false
+            if halt_on_infeasible_schedule
+                # TODO: Find a place for this useful code
+                #compute_conflict!(model)
+                #println("Constraints in conflict:")
+                #for con in all_constraints(model, include_variable_in_set_constraints=true)
+                #    status = MOI.get(model, MOI.ConstraintConflictStatus(), con)
+                #    if status == MOI.IN_CONFLICT
+                #        println(con)
+                #    end
+                #end
+                return solve_data
+            end
+        end
+
+        # All the conditions required for schedule_data to have reserves
+        if (
+            include_reserves_in_schedule
+            && feasible_schedule
+            && !schedule_close_to_initial
+            && sdd_fraction_to_constrain > 0.0
         )
-    end
+            pos_reserve_value, neg_reserve_value = compute_device_reserve_values(input_data, schedule_data)
+
+            topo_data = preprocess_topology_data(input_data)
+            sdd2bus = Dict()
+            for bus_id in input_data.bus_ids
+                for sdd_id in topo_data.bus_sdd_ids[bus_id]
+                    sdd2bus[sdd_id] = bus_id
+                end
+            end
+            has_shunt = Dict(uid => (length(topo_data.bus_shunt_ids[sdd2bus[uid]]) >= 1) for uid in input_data.sdd_ids)
+
+            println("Computing costs for fixing devices")
+            # Estimate of (local) power balance violation penalty we will take by
+            # *preventing the device from decreasing*
+            balance_costs = compute_device_balance_costs(input_data, schedule_data, allow_switching = allow_switching)
+            println("Done computing costs")
+
+            net_value_for_lb = Dict(uid => (neg_reserve_value[uid] - balance_costs[uid]) for uid in input_data.sdd_ids)
+            net_value_for_ub = Dict(uid => (pos_reserve_value[uid] - balance_costs[uid]) for uid in input_data.sdd_ids)
+
+            sdd_by_ub_value = sort(input_data.sdd_ids, by = uid -> net_value_for_ub[uid], rev = true)
+            sdd_by_lb_value = sort(input_data.sdd_ids, by = uid -> net_value_for_lb[uid], rev = true)
+            sdd_by_ub_pos = [uid for uid in sdd_by_ub_value if net_value_for_ub[uid] > 0 && balance_costs[uid] == 0 && !has_shunt[uid]]
+            sdd_by_lb_pos = [uid for uid in sdd_by_lb_value if net_value_for_lb[uid] > 0 && balance_costs[uid] == 0 && !has_shunt[uid]]
+
+            n_to_ub = Int64(round(sdd_fraction_to_constrain * length(sdd_by_ub_pos)))
+            n_to_lb = Int64(round(sdd_fraction_to_constrain * length(sdd_by_lb_pos)))
+
+            sdd_to_ub = sdd_by_ub_pos[1:n_to_ub]
+            sdd_to_lb = sdd_by_lb_pos[1:n_to_lb]
+
+            println("SDD TO BE UPPER BOUNDED THROUGHOUT OPF SOLVES")
+            println("---------------------------------------------")
+            for (i, uid) in enumerate(sdd_to_ub)
+                println("$i: uid=$uid, reserve value = $(pos_reserve_value[uid]), balance cost = $(balance_costs[uid]), net value = $(net_value_for_ub[uid])")
+            end
+            println("---------------------------------------------")
+            println("SDD TO BE LOWER BOUNDED THROUGHOUT OPF SOLVES")
+            println("---------------------------------------------")
+            for (i, uid) in enumerate(sdd_to_lb)
+                println("$i: uid=$uid, reserve value = $(neg_reserve_value[uid]), balance cost = $(balance_costs[uid]), net value = $(net_value_for_lb[uid])")
+            end
+            println("---------------------------------------------")
+        else
+            sdd_to_ub = []
+            sdd_to_lb = []
+        end
+
+        timing_data["schedule_total"] = time() - time_mip_start
+
+        time_opf_start = time()
+
+        on_status = schedule_data.on_status
+        real_power = schedule_data.real_power
+
+        if tighten_bounds_pre_opf && feasible_schedule
+            # Only tighten bounds if we have a feasible schedule. Otherwise bounds
+            # can cross, and we don't handle that case here.
+            processed_data = tighten_bounds_using_ramp_limits(
+                input_data, on_status, real_power
+            )
+        else
+            processed_data = input_data
+        end
+
+        #
+        # Solve ACOPF problem for every time period
+        #
+        if parallel_opf
+            # First, compute in parallel
+            acopf_solutions = compute_opf_in_parallel(
+                processed_data,
+                on_status,
+                real_power;
+                optimizer = nlp_optimizer,
+                ipopt_linear_solver = linear_solver,
+                fix_real_power = fix_ac_real_power,
+                penalize_power_deviation = true,
+                allow_switching = allow_switching,
+                resolve_rounded_shunts = resolve_rounded_shunts,
+                fix_shunt_steps = !resolve_rounded_shunts,
+                relax_thermal_limits = relax_thermal_limits,
+                sdd_to_lb = sdd_to_lb,
+                sdd_to_ub = sdd_to_ub,
+            )
+
+            acopf_solve_data = [data for (_, data) in acopf_solutions]
+            #
+            # Construct serializable solution data structure
+            #
+            solfile_dict = construct_solution_dict(
+                input_data,
+                schedule_data;
+                opf_data = acopf_solve_data,
+                write_duals = write_duals,
+                include_reserves = true,
+                # We need postprocessing after the parallel solves to make sure that
+                # ramping constraints are satisfied.
+                #
+                # TODO: Why is postprocessing combined with construction of the
+                # solution data structure? Just to make this function simpler?
+                postprocess = true,
+                print_projected_devices = print_projected_devices,
+            )
+
+            #
+            # Write out solution file
+            #
+            if "solution_file" in keys(args)
+                solution_fpath = args["solution_file"]
+                # Defer making the solution file directory until now so that we hopefully
+                # only make this directory if we are going to put something in it.
+                mkpath(dirname(solution_fpath))
+                open(io -> JSON.print(io, solfile_dict, 4), solution_fpath, "w")
+                println("Wrote solution file at $(time() - start_time) s")
+                println("(after start of run_ac_uc_solver)")
+            end
+
+            #
+            # Now, if we used a parallel, fully-independent solve previously, we
+            # re-solve with sequential OPF solves to try to achieve a better solution
+            # than the solve-independently-and-project solution gives us.
+            #
+            if post_parallel_sequential
+                acopf_solutions = compute_optimal_power_flows(
+                    processed_data,
+                    on_status,
+                    real_power;
+                    # In this post-parallel solve, we always solve sequentially.
+                    sequential = true,
+                    optimizer = nlp_optimizer,
+                    ipopt_linear_solver = linear_solver,
+                    fix_real_power = fix_ac_real_power,
+                    penalize_power_deviation = true,
+                    allow_switching = allow_switching,
+                    resolve_rounded_shunts = resolve_rounded_shunts,
+                    fix_shunt_steps = !resolve_rounded_shunts,
+                    relax_thermal_limits = relax_thermal_limits,
+                    sdd_to_lb = sdd_to_lb,
+                    sdd_to_ub = sdd_to_ub,
+                )
+            end
+        elseif multiperiod_opf
+            if fix_ac_real_power
+                throw(ArgumentError("multiperiod_opf cannot be used with fix_ac_real_power"))
+            end
+            if resolve_rounded_shunts
+                throw(ArgumentError("multiperiod_opf does not support re-solving shunts yet"))
+            end
+            if relax_thermal_limits
+                throw(ArgumentError("multiperiod_opf does not support relax_thermal_limits"))
+            end
+            _, mpacopf_solution = compute_multiperiod_opf(
+                processed_data,
+                on_status;
+                optimizer = nlp_optimizer,
+                ipopt_linear_solver = linear_solver,
+                return_model = false,
+            )
+            # Reshape the solution data for consistency with other subroutines
+            acopf_solutions = [
+                (nothing, Dict(
+                    key => Dict(
+                        uid => Dict(
+                            attr => device[attr][i] for attr in keys(device)
+                        ) for (uid, device) in devicedict
+                    ) for (key, devicedict) in mpacopf_solution
+                )) for i in periods
+            ]
+        else
+            # This is a non-parallel default. It can solve OPF subproblems
+            # independently or sequentially. This is controlled by the sequential_opf
+            # option.
+            acopf_solutions = compute_optimal_power_flows(
+                processed_data,
+                on_status,
+                real_power;
+                sequential = sequential_opf,
+                optimizer = nlp_optimizer,
+                ipopt_linear_solver = linear_solver,
+                fix_real_power = fix_ac_real_power,
+                penalize_power_deviation = true,
+                allow_switching = allow_switching,
+                resolve_rounded_shunts = resolve_rounded_shunts,
+                fix_shunt_steps = !resolve_rounded_shunts,
+                relax_thermal_limits = relax_thermal_limits,
+                sdd_to_lb = sdd_to_lb,
+                sdd_to_ub = sdd_to_ub,
+            )
+        end
+
+        timing_data["opf_total"] = time() - time_opf_start
+    end # End "!simultaneous_acuc"" clause.
 
     acopf_solve_data = [data for (_, data) in acopf_solutions]
 
@@ -478,8 +532,6 @@ function run_ac_uc_solver(args::Dict)
             println("  $(ac_pr_status), $(obj_val)")
         end
     end
-
-    timing_data["opf_total"] = time() - time_opf_start
 
     #
     # Display results
@@ -523,7 +575,7 @@ function run_ac_uc_solver(args::Dict)
         schedule_data;
         opf_data = acopf_solve_data,
         write_duals = write_duals,
-        include_reserves = false,
+        include_reserves = true,
         postprocess = postprocess_final_solution,
         print_projected_devices = print_projected_devices,
     )

--- a/src/ac_uc_solver.jl
+++ b/src/ac_uc_solver.jl
@@ -78,6 +78,7 @@ function run_ac_uc_solver(args::Dict)
     if simultaneous_acuc && minlp_optimizer === nothing
         throw(ArgumentError("minlp_optimizer must be provided if simultaneous_acuc is used"))
     end
+    include_reserves_in_solution = get(args, "include_reserves_in_solution", true)
 
     #
     # Options for MIP solve
@@ -575,7 +576,7 @@ function run_ac_uc_solver(args::Dict)
         schedule_data;
         opf_data = acopf_solve_data,
         write_duals = write_duals,
-        include_reserves = true,
+        include_reserves = include_reserves_in_solution,
         postprocess = postprocess_final_solution,
         print_projected_devices = print_projected_devices,
     )

--- a/src/opf_model.jl
+++ b/src/opf_model.jl
@@ -1622,9 +1622,18 @@ on_status is required so we can distinguish between p_on and p_su/sd.
 function extract_data_from_multiperiod_model(
     model, 
     data,
-    on_status,
+    on_status;
+    p_sdd=nothing,
+    q_sdd=nothing,
 )
     solution_data = Dict{String, Any}()
+
+    if p_sdd === nothing
+        p_sdd = model[:p_sdd]
+    end
+    if q_sdd === nothing
+        q_sdd = model[:q_sdd]
+    end
 
     #
     # Add solution data for buses
@@ -1670,11 +1679,11 @@ function extract_data_from_multiperiod_model(
             # Probably don't even need to include on_status in this dict.
             "on_status" => on_status[uid],
             "p_on" => [0.0 for _ in data.periods],
-            "q" => Vector(JuMP.value.(model[:q_sdd][uid, :])),
+            "q" => Vector(JuMP.value.(q_sdd[uid, :])),
         )
         for i in data.periods
             if Bool(on_status[uid][i])
-                sdd_uid_map["p_on"][i] = JuMP.value(model[:p_sdd][uid, i])
+                sdd_uid_map["p_on"][i] = JuMP.value(p_sdd[uid, i])
             end
         end
         sdd_map[uid] = sdd_uid_map


### PR DESCRIPTION
The model may be constructed via
```julia
import GOC3Benchmark as goc
problem_file = "path/to/file.json"
input_data = goc.get_data_from_file(problem_file)
acuc_model = goc.get_ac_uc_model(input_data)
```

This model can be used in the `goc.run_ac_uc_solver` function via `"simultaneous_acuc" => true` in the `args` dict passed to this function.

This PR also reverts a change I made in the previous, multiperiod-opf, PR that was intended to be temporary. I turned off post-OPF reserve calculation for testing and forgot to turn it back on.